### PR TITLE
LTS Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,40 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
-jobs:
+workflows:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:10.15
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: npm ci
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-
-      # run tests!
-      - run: npm test
+    jobs:
+      - build-lts-12:
+          docker:
+            - image: node:12
+          working_directory: ~/repo
+          steps:
+            - checkout
+            - restore_cache:
+                keys:
+                  - v1-dependencies-{{ checksum "package.json" }}
+                  - v1-dependencies-
+            - run: npm ci
+            - run: npm test
+      - build-lts-10:
+          docker:
+            - image: node:10
+          working_directory: ~/repo
+          steps:
+            - checkout
+            - restore_cache:
+                keys:
+                  - v1-dependencies-{{ checksum "package.json" }}
+                  - v1-dependencies-
+            - run: npm ci
+            - run: npm test
+      - build-lts-8:
+          docker:
+            - image: node:8
+          working_directory: ~/repo
+          steps:
+            - checkout
+            - restore_cache:
+                keys:
+                  - v1-dependencies-{{ checksum "package.json" }}
+                  - v1-dependencies-
+            - run: npm ci
+            - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,49 @@
-version: 2
+version: 2.0
+
+jobs:
+  build-lts-12:
+    docker:
+      - image: node:12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: npm ci
+      - run: npm test
+
+  build-lts-10:
+    docker:
+      - image: node:10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: npm ci
+      - run: npm test
+
+  build-lts-8:
+    docker:
+      - image: node:8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: npm ci
+      - run: npm test
+
 workflows:
-  build:
+  version: 2
+  build-and-test:
     jobs:
-      - build-lts-12:
-          docker:
-            - image: node:12
-          working_directory: ~/repo
-          steps:
-            - checkout
-            - restore_cache:
-                keys:
-                  - v1-dependencies-{{ checksum "package.json" }}
-                  - v1-dependencies-
-            - run: npm ci
-            - run: npm test
-      - build-lts-10:
-          docker:
-            - image: node:10
-          working_directory: ~/repo
-          steps:
-            - checkout
-            - restore_cache:
-                keys:
-                  - v1-dependencies-{{ checksum "package.json" }}
-                  - v1-dependencies-
-            - run: npm ci
-            - run: npm test
-      - build-lts-8:
-          docker:
-            - image: node:8
-          working_directory: ~/repo
-          steps:
-            - checkout
-            - restore_cache:
-                keys:
-                  - v1-dependencies-{{ checksum "package.json" }}
-                  - v1-dependencies-
-            - run: npm ci
-            - run: npm test
+      - build-lts-12
+      - build-lts-10
+      - build-lts-8

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Jason Jacob
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accept-language-negotiator",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "RFC4647 compliant Accept-Language parser for node",
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import {languagePriorityList, basicFilter, lookup, extendedFilter} from '../src/index';
+import { languagePriorityList, basicFilter, lookup, extendedFilter } from '../src/index';
 
 describe('accept-language-node', () => {
   describe('languagePriorityList', () => {
@@ -8,88 +8,124 @@ describe('accept-language-node', () => {
     });
 
     it('should assign default quality if languagePriorityList quality fails', () => {
-      assert.deepStrictEqual(languagePriorityList('en;q0.1'), [{ tag: 'en', quality: 1 }],
-        'expected to languagePriorityList single tag');
+      assert.deepStrictEqual(
+        languagePriorityList('en;q0.1'),
+        [{ tag: 'en', quality: 1 }],
+        'expected to languagePriorityList single tag'
+      );
     });
 
     it('should assign default quality if languagePriorityList quality is higher than 1', () => {
-      assert.deepStrictEqual(languagePriorityList('en;q=undefined'), [{ tag: 'en', quality: 1 }],
-        'expected to languagePriorityList single tag');
+      assert.deepStrictEqual(
+        languagePriorityList('en;q=undefined'),
+        [{ tag: 'en', quality: 1 }],
+        'expected to languagePriorityList single tag'
+      );
     });
 
     it('should assign default quality if languagePriorityList quality is higher than 1', () => {
-      assert.deepStrictEqual(languagePriorityList('en;q=1.1'), [{tag: 'en', quality: 1}],
-        'expected to languagePriorityList single tag');
+      assert.deepStrictEqual(
+        languagePriorityList('en;q=1.1'),
+        [{ tag: 'en', quality: 1 }],
+        'expected to languagePriorityList single tag'
+      );
     });
 
     it('should return wildcard when given value other than a string', () => {
-      assert.deepStrictEqual(languagePriorityList(undefined), [{tag: '*', quality: 1}], '* obj expected');
-      assert.deepStrictEqual(languagePriorityList(null), [{tag: '*', quality: 1}], '* obj expected');
-      assert.deepStrictEqual(languagePriorityList(1), [{tag: '*', quality: 1}], '* obj expected');
-      assert.deepStrictEqual(languagePriorityList(true), [{tag: '*', quality: 1}], '* obj expected');
-      assert.deepStrictEqual(languagePriorityList({}), [{tag: '*', quality: 1}], '* obj expected');
-      assert.deepStrictEqual(languagePriorityList([]), [{tag: '*', quality: 1}], '* obj expected');
+      assert.deepStrictEqual(languagePriorityList(undefined), [{ tag: '*', quality: 1 }], '* obj expected');
+      assert.deepStrictEqual(languagePriorityList(null), [{ tag: '*', quality: 1 }], '* obj expected');
+      assert.deepStrictEqual(languagePriorityList(1), [{ tag: '*', quality: 1 }], '* obj expected');
+      assert.deepStrictEqual(languagePriorityList(true), [{ tag: '*', quality: 1 }], '* obj expected');
+      assert.deepStrictEqual(languagePriorityList({}), [{ tag: '*', quality: 1 }], '* obj expected');
+      assert.deepStrictEqual(languagePriorityList([]), [{ tag: '*', quality: 1 }], '* obj expected');
     });
 
     it('should split range string correctly into objects', () => {
-      assert.deepStrictEqual(languagePriorityList('*'), [{tag: '*', quality: 1}], 'expected to languagePriorityList');
-      assert.deepStrictEqual(languagePriorityList('en'), [{tag: 'en', quality: 1}], 'expected to languagePriorityList');
-      assert.deepStrictEqual(languagePriorityList('en-US'), [{tag: 'en-US', quality: 1}], 'expected to languagePriorityList');
+      assert.deepStrictEqual(languagePriorityList('*'), [{ tag: '*', quality: 1 }], 'expected to languagePriorityList');
+      assert.deepStrictEqual(
+        languagePriorityList('en'),
+        [{ tag: 'en', quality: 1 }],
+        'expected to languagePriorityList'
+      );
+      assert.deepStrictEqual(
+        languagePriorityList('en-US'),
+        [{ tag: 'en-US', quality: 1 }],
+        'expected to languagePriorityList'
+      );
 
-      assert.deepStrictEqual(languagePriorityList('zh-Hant-CN-x-private1-private2'), [{tag: 'zh-Hant-CN-x-private1-private2',
-        quality: 1}], 'expected to correctly languagePriorityList private into valid tag objects');
+      assert.deepStrictEqual(
+        languagePriorityList('zh-Hant-CN-x-private1-private2'),
+        [{ tag: 'zh-Hant-CN-x-private1-private2', quality: 1 }],
+        'expected to correctly languagePriorityList private into valid tag objects'
+      );
 
-      assert.deepStrictEqual(languagePriorityList('en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5, *'), [
-        { tag: '*', quality: 1 },
-        { tag: 'en-GB', quality: 1 },
-        { tag: 'fr-CA', quality: 0.8 },
-        { tag: 'en-US', quality: 0.7 },
-        { tag: 'en', quality: 0.5 }
-      ], 'expected to correctly languagePriorityList range into valid tag objects');
+      assert.deepStrictEqual(
+        languagePriorityList('en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5, *'),
+        [
+          { tag: '*', quality: 1 },
+          { tag: 'en-GB', quality: 1 },
+          { tag: 'fr-CA', quality: 0.8 },
+          { tag: 'en-US', quality: 0.7 },
+          { tag: 'en', quality: 0.5 }
+        ],
+        'expected to correctly languagePriorityList range into valid tag objects'
+      );
     });
 
     it('should return sorted in order quality, tag specificity from high to low', () => {
-      assert.deepStrictEqual(languagePriorityList('en-GB,en-US;q=0.7,zh-Hant-CN;q=0.8,fr-CA;q=0.8,en;q=0.5'), [
-        { tag: 'en-GB', quality: 1 },
-        { tag: 'zh-Hant-CN', quality: 0.8},
-        { tag: 'fr-CA', quality: 0.8 },
-        { tag: 'en-US', quality: 0.7 },
-        { tag: 'en', quality: 0.5 }
-      ], 'expected to correctly languagePriorityList range into valid tag objects');
+      assert.deepStrictEqual(
+        languagePriorityList('en-GB,en-US;q=0.7,zh-Hant-CN;q=0.8,fr-CA;q=0.8,en;q=0.5'),
+        [
+          { tag: 'en-GB', quality: 1 },
+          { tag: 'zh-Hant-CN', quality: 0.8 },
+          { tag: 'fr-CA', quality: 0.8 },
+          { tag: 'en-US', quality: 0.7 },
+          { tag: 'en', quality: 0.5 }
+        ],
+        'expected to correctly languagePriorityList range into valid tag objects'
+      );
     });
 
     it('wild card tag should always be sorted to first position', () => {
-      assert.deepStrictEqual(languagePriorityList('en-GB,en-US;q=0.7,*,zh-Hant-CN;q=0.8,fr-CA;q=0.8,en;q=0.5'), [
-        { tag: '*', quality: 1 },
-        { tag: 'en-GB', quality: 1 },
-        { tag: 'zh-Hant-CN', quality: 0.8},
-        { tag: 'fr-CA', quality: 0.8 },
-        { tag: 'en-US', quality: 0.7 },
-        { tag: 'en', quality: 0.5 }
-      ], 'expected to correctly languagePriorityList range into valid tag objects');
+      assert.deepStrictEqual(
+        languagePriorityList('en-GB,en-US;q=0.7,*,zh-Hant-CN;q=0.8,fr-CA;q=0.8,en;q=0.5'),
+        [
+          { tag: '*', quality: 1 },
+          { tag: 'en-GB', quality: 1 },
+          { tag: 'zh-Hant-CN', quality: 0.8 },
+          { tag: 'fr-CA', quality: 0.8 },
+          { tag: 'en-US', quality: 0.7 },
+          { tag: 'en', quality: 0.5 }
+        ],
+        'expected to correctly languagePriorityList range into valid tag objects'
+      );
 
-      assert.deepStrictEqual(languagePriorityList('*,en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5'), [
-        {
-          quality: 1,
-          tag: '*'
-        },
-        {
-          quality: 1,
-          tag: 'en-GB'
-        },
-        {
-          quality: 0.8,
-          tag: 'fr-CA'
-        },
-        {
-          quality: 0.7,
-          tag: 'en-US'
-        },
-        {
-          quality: 0.5,
-          tag: 'en'
-        }
-      ], 'expected to correctly languagePriorityList range into valid tag objects');
+      assert.deepStrictEqual(
+        languagePriorityList('*,en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5'),
+        [
+          {
+            quality: 1,
+            tag: '*'
+          },
+          {
+            quality: 1,
+            tag: 'en-GB'
+          },
+          {
+            quality: 0.8,
+            tag: 'fr-CA'
+          },
+          {
+            quality: 0.7,
+            tag: 'en-US'
+          },
+          {
+            quality: 0.5,
+            tag: 'en'
+          }
+        ],
+        'expected to correctly languagePriorityList range into valid tag objects'
+      );
     });
   });
 
@@ -103,35 +139,57 @@ describe('accept-language-node', () => {
     });
 
     it('should return an empty array if no match is found', () => {
-      assert.deepStrictEqual(basicFilter('en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5', ['ru', 'it']), [],
-        'expected empty array to be returned if no match is made');
+      assert.deepStrictEqual(
+        basicFilter('en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5', ['ru', 'it']),
+        [],
+        'expected empty array to be returned if no match is made'
+      );
     });
 
     it('should match all when wildcard is present', () => {
-      assert.deepStrictEqual(basicFilter('*,en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5, ',
-        ['zh-Hant-CN-x-private1-private2', 'en', 'zh']), ['zh-Hant-CN-x-private1-private2', 'en', 'zh'],
-        'should return all matches if wild card is present');
+      assert.deepStrictEqual(
+        basicFilter('*,en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5, ', ['zh-Hant-CN-x-private1-private2', 'en', 'zh']),
+        ['zh-Hant-CN-x-private1-private2', 'en', 'zh'],
+        'should return all matches if wild card is present'
+      );
     });
 
     it('should match when priority tag and language tag exactly match', () => {
-      assert.deepStrictEqual(basicFilter('zh-Hant-CN-x-private1-private2', ['zh-Hant-CN-x-private1-private2']),
-        ['zh-Hant-CN-x-private1-private2'], 'should match');
+      assert.deepStrictEqual(
+        basicFilter('zh-Hant-CN-x-private1-private2', ['zh-Hant-CN-x-private1-private2']),
+        ['zh-Hant-CN-x-private1-private2'],
+        'should match'
+      );
     });
 
     it('should match prefix correctly when direct match can not be made', () => {
-      assert.deepStrictEqual(basicFilter('de-de', ['de-DE', 'de-DE-1996', 'de-Deva', 'de-Latn-DE']),
-        ['de-DE', 'de-DE-1996'], 'should match');
+      assert.deepStrictEqual(
+        basicFilter('de-de', ['de-DE', 'de-DE-1996', 'de-Deva', 'de-Latn-DE']),
+        ['de-DE', 'de-DE-1996'],
+        'should match'
+      );
     });
 
     it('should match all when only language is given in language range', () => {
-      assert.deepStrictEqual(basicFilter('de', ['de-DE', 'de-DE-1996', 'de-Deva', 'de-Latn-DE']),
-        ['de-DE', 'de-DE-1996', 'de-Deva', 'de-Latn-DE'], 'should match');
+      assert.deepStrictEqual(
+        basicFilter('de', ['de-DE', 'de-DE-1996', 'de-Deva', 'de-Latn-DE']),
+        ['de-DE', 'de-DE-1996', 'de-Deva', 'de-Latn-DE'],
+        'should match'
+      );
     });
 
     it('should return results in Priority List order', () => {
-      assert.deepStrictEqual(basicFilter('en-GB,en-US;q=0.7,zh-Hant-CN-x-private1-private2;q=0.8,fr-CA;q=0.8,en;q=0.5',
-        ['en-GB', 'en-US', 'zh-Hant-CN-x-private1-private2', 'fr-CA', 'en']),
-        ['en-GB', 'zh-Hant-CN-x-private1-private2', 'fr-CA', 'en-US', 'en'], 'should be in order');
+      assert.deepStrictEqual(
+        basicFilter('en-GB,en-US;q=0.7,zh-Hant-CN-x-private1-private2;q=0.8,fr-CA;q=0.8,en;q=0.5', [
+          'en-GB',
+          'en-US',
+          'zh-Hant-CN-x-private1-private2',
+          'fr-CA',
+          'en'
+        ]),
+        ['en-GB', 'zh-Hant-CN-x-private1-private2', 'fr-CA', 'en-US', 'en'],
+        'should be in order'
+      );
     });
   });
 
@@ -145,27 +203,23 @@ describe('accept-language-node', () => {
     });
 
     it('should match extended tag correctly as described in RFC 3.3.2', () => {
-      assert.deepStrictEqual(extendedFilter('de-*-DE', [
-        // testing
-        'ru',               // should fail
-        'de',               // should fail
-        'de-DE',
-        'de-de',
-        'de-Latn-DE',
-        'de-DE-x-goethe',
-        'de-Latn-DE-1996',
-        'de-Deva-DE',
-        'de-x-DE',          // should fail
-        'de-Deva'           // should fail
-      ]), [
-        'de-DE',
-        'de-de',
-        'de-Latn-DE',
-        'de-DE-x-goethe',
-        'de-Latn-DE-1996',
-        'de-Deva-DE'
-      ],
-        'expected extended tag to match');
+      assert.deepStrictEqual(
+        extendedFilter('de-*-DE', [
+          // testing
+          'ru', // should fail
+          'de', // should fail
+          'de-DE',
+          'de-de',
+          'de-Latn-DE',
+          'de-DE-x-goethe',
+          'de-Latn-DE-1996',
+          'de-Deva-DE',
+          'de-x-DE', // should fail
+          'de-Deva' // should fail
+        ]),
+        ['de-DE', 'de-de', 'de-Latn-DE', 'de-DE-x-goethe', 'de-Latn-DE-1996', 'de-Deva-DE'],
+        'expected extended tag to match'
+      );
     });
   });
 
@@ -175,46 +229,65 @@ describe('accept-language-node', () => {
     });
 
     it('should throw if correct args are not supplied', () => {
-      assert.throws(() => lookup('stuff'), Error('range:String, languageTags:Array, defaultValue:String required!'),
-        'should throw error if arguments are not supplied');
+      assert.throws(
+        () => lookup('stuff'),
+        Error('range:String, languageTags:Array, defaultValue:String required!'),
+        'should throw error if arguments are not supplied'
+      );
     });
 
     it('should choose direct match over partial', () => {
-      assert.equal(lookup('en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5', ['fr-CA', 'fr-FR', 'fr', 'en', 'ru'], 'en'),
-        'fr-CA', 'expected direct match to be chosen');
+      assert.equal(
+        lookup('en-GB,en-US;q=0.7,fr-CA;q=0.8,en;q=0.5', ['fr-CA', 'fr-FR', 'fr', 'en', 'ru'], 'en'),
+        'fr-CA',
+        'expected direct match to be chosen'
+      );
     });
 
     it('should return default if supportedLanguages is not an array', () => {
-      assert.strictEqual(lookup('en', {en: 'english'}, 'ru'), 'ru',
-        'should return default if languages is not an array');
+      assert.strictEqual(
+        lookup('en', { en: 'english' }, 'ru'),
+        'ru',
+        'should return default if languages is not an array'
+      );
     });
 
     it('should return default if supportedLanguages is empty', () => {
-      assert.strictEqual(lookup('en', [], 'ru'), 'ru',
-        'should return default if languages is not an array');
+      assert.strictEqual(lookup('en', [], 'ru'), 'ru', 'should return default if languages is not an array');
     });
 
     it('should return default if no match is made', () => {
-      assert.strictEqual(lookup('zh-Hant-CN-x-private1-private2', ['en', 'en-US'], 'ru'), 'ru',
-        'should return default if languages is not an array');
+      assert.strictEqual(
+        lookup('zh-Hant-CN-x-private1-private2', ['en', 'en-US'], 'ru'),
+        'ru',
+        'should return default if languages is not an array'
+      );
     });
 
     it('Should match correctly', () => {
-      assert.strictEqual(lookup('zh-Hant-CN-x-private1-private2', ['zh-Hant', 'zh'], 'en-US'), 'zh-Hant',
-        'Should match');
-      assert.strictEqual(lookup('zh-Hant', ['zh', 'zh-Hant-CN-x-private1-private2'], 'en-US'), 'zh-Hant',
-        'Should Match');
+      assert.strictEqual(
+        lookup('zh-Hant-CN-x-private1-private2', ['zh-Hant', 'zh'], 'en-US'),
+        'zh-Hant',
+        'Should match'
+      );
+      assert.strictEqual(
+        lookup('zh-Hant', ['zh', 'zh-Hant-CN-x-private1-private2'], 'en-US'),
+        'zh-Hant',
+        'Should Match'
+      );
       assert.strictEqual(lookup('zh-Hant', ['zh-Hant'], 'en-US'), 'zh-Hant', 'Should Match direct');
     });
 
     it('Should not match a language tag with greater specificity than the range tag', () => {
-      assert.strictEqual(lookup('de-CH', ['de-CH-1996'], 'en-US'), 'de-CH',
-        'expected correct specificity');
+      assert.strictEqual(lookup('de-CH', ['de-CH-1996'], 'en-US'), 'de-CH', 'expected correct specificity');
     });
 
     it('Should not match on singleton', () => {
-      assert.strictEqual(lookup('zh-Hant-CN-x-blah', ['zh-Hant-CN-x-private1-private2'], 'en-US'), 'zh-Hant-CN',
-        'expected singleton to be truncated on match');
+      assert.strictEqual(
+        lookup('zh-Hant-CN-x-blah', ['zh-Hant-CN-x-private1-private2'], 'en-US'),
+        'zh-Hant-CN',
+        'expected singleton to be truncated on match'
+      );
     });
   });
 });


### PR DESCRIPTION
**Overview:**
Changes in Node 11 to the way the sort params order in an arrays are passed in see https://github.com/nodejs/node/issues/24294 surfaced a bug in sorting.

**Changes**
This PR changes the following:
- sorts do not rely on order
  - sorts now returns -1, 0, 1 (lt, eq, gt)
- sort functions are now more readable and not so dense
- remove excess function calls
- add ci tests for each LTS
  - 12
  - 10
  - 8