### PR TITLE
Expose to users that the src/index.js should be used in ESM environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "homepage": "https://github.com/jayco/accept-language-negotiator#readme",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "NODE_ENV=test mocha --require @babel/register --recursive",
     "cov": "NODE_ENV=test COVERAGE=yes LOG_LEVEL=fatal istanbul cover --report html ./node_modules/.bin/_mocha -- --require @babel/register --recursive && open coverage/index.html",


### PR DESCRIPTION
See https://github.com/rollup/rollup/wiki/pkg.module and this discussion in StackOverflow for some more details: https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for

As a work-around until this is done: In ESM environments use 

```ts
import { lookup } from 'accept-language-negotiator/src';
```
